### PR TITLE
 Namenänderung

### DIFF
--- a/IWasHere.txt
+++ b/IWasHere.txt
@@ -1,0 +1,1 @@
+Josef Maßen


### PR DESCRIPTION
Josef Maaßen hat seinen Namen geändert und ihn aus Versehen falsch
geschrieben.
